### PR TITLE
Allow derived attributes to satisfy to satisfy authorization requirement

### DIFF
--- a/Torutek.Auth/RequireAuthorizeAttributeFilter.cs
+++ b/Torutek.Auth/RequireAuthorizeAttributeFilter.cs
@@ -23,7 +23,7 @@ namespace Torutek.Auth
 				var desc = (ControllerActionDescriptor)context.ActionDescriptor;
 
 				var allAttrs = desc.MethodInfo.CustomAttributes.Concat(desc.ControllerTypeInfo.CustomAttributes);
-				if (!allAttrs.Any(attr => attr.AttributeType == typeof(AuthorizeAttribute) || attr.AttributeType == typeof(AllowAnonymousAttribute)))
+				if (!allAttrs.Any(attr => IsSameOrSubclass(typeof(AuthorizeAttribute), attr.AttributeType) || IsSameOrSubclass(typeof(AllowAnonymousAttribute), attr.AttributeType)))
 					throw new Exception("You (Developer) need to add an [Authorize] or [AllowAnonymous] attribute on this controller or method");
 			}
 			else
@@ -31,6 +31,12 @@ namespace Torutek.Auth
 				throw new Exception("Not sure how to enforce [Authorize]/[AllowAnonymous] Attributes on this thing");
 			}
 			return Task.FromResult(true);
+		}
+
+		private bool IsSameOrSubclass(Type potentialBase, Type potentialDescendant)
+		{
+			return potentialDescendant.IsSubclassOf(potentialBase)
+				   || potentialDescendant == potentialBase;
 		}
 	}
 }


### PR DESCRIPTION
It's fairly common to create a class that derives from AuthorizeAttribute in order to add additional functionality or improve the usability of the Attribute itself, e.g:

```
public class Authorize : AuthorizeAttribute
{
	public Authorize()
	{
	}

	public Authorize(params string[] roles)
	{
		Roles = string.Join(',', roles);
	}
}
```

This PR modifies the behaviour of the filter to let these attributes satisfy the authorization requirement.